### PR TITLE
Re-export public structs and traits

### DIFF
--- a/src/isbn.rs
+++ b/src/isbn.rs
@@ -13,14 +13,14 @@ impl ISBN {
   /// Returns an Option<char> if the ISBN is a valid length
   ///
   /// ```
-  /// use library_stdnums::isbn::ISBN;
+  /// use library_stdnums::ISBN;
   /// assert_eq!(ISBN::new("0139381430").checkdigit().unwrap(), '0');
   /// ```
   ///
   /// Returns None if the ISBN content is not valid length
   ///
   /// ```
-  /// use library_stdnums::isbn::ISBN;
+  /// use library_stdnums::ISBN;
   /// assert_eq!(ISBN::new("Bad ISBN").checkdigit(), None);
   /// ```
   pub fn checkdigit(&self) -> Option<char> {
@@ -36,21 +36,21 @@ impl ISBN {
   /// Returns an Option<String> if the ISBN is valid
   /// 
   /// ```
-  /// use library_stdnums::isbn::ISBN;
+  /// use library_stdnums::ISBN;
   /// assert_eq!(ISBN::new("0-306-40615-2").convert_to_13().unwrap(), "9780306406157");
   /// ```
   /// 
   /// /// Returns an Option<String> if the ISBN is valid and already an ISBN13
   /// 
   /// ```
-  /// use library_stdnums::isbn::ISBN;
+  /// use library_stdnums::ISBN;
   /// assert_eq!(ISBN::new("978-1-449-37332-0").convert_to_13().unwrap(), "9781449373320");
   /// ```
   ///
   /// Returns None if the ISBN is invalid
   ///
   /// ```
-  /// use library_stdnums::isbn::ISBN;
+  /// use library_stdnums::ISBN;
   /// assert_eq!(ISBN::new("013938143").convert_to_13(), None);
   /// ```
   pub fn convert_to_13(&self) -> Option<String> {
@@ -69,21 +69,21 @@ impl ISBN {
   /// Returns an Option<String> if the ISBN is valid
   /// 
   /// ```
-  /// use library_stdnums::isbn::ISBN;
+  /// use library_stdnums::ISBN;
   /// assert_eq!(ISBN::new("9780306406157").convert_to_10().unwrap(), "0306406152");
   /// ```
   ///
   /// Returns None if the ISBN is invalid
   ///
   /// ```
-  /// use library_stdnums::isbn::ISBN;
+  /// use library_stdnums::ISBN;
   /// assert_eq!(ISBN::new("013938143").convert_to_10(), None);
   /// ```
   /// 
   /// Returns None if an ISBN13 begins with '979'
   /// 
   /// ```
-  /// use library_stdnums::isbn::ISBN;
+  /// use library_stdnums::ISBN;
   /// assert_eq!(ISBN::new("9798531132178").convert_to_10(), None);
   /// ```
   pub fn convert_to_10(&self) -> Option<String> {
@@ -111,16 +111,16 @@ impl Valid for ISBN {
   /// Returns true if the ISBN is valid
   /// 
   /// ```
-  /// use library_stdnums::isbn::ISBN;
-  /// use library_stdnums::traits::Valid;
+  /// use library_stdnums::ISBN;
+  /// use library_stdnums::Valid;
   /// assert!(ISBN::new("0139381430").valid());
   /// ```
   ///
   /// Returns false if the ISBN is invalid
   ///
   /// ```
-  /// use library_stdnums::isbn::ISBN;
-  /// use library_stdnums::traits::Valid;
+  /// use library_stdnums::ISBN;
+  /// use library_stdnums::Valid;
   /// assert_eq!(ISBN::new("0139381432").valid(), false);
   /// ```
   fn valid(&self) -> bool {
@@ -139,8 +139,8 @@ impl Normalize for ISBN {
   /// Returns an Option<String> if the ISBN is valid
   /// 
   /// ```
-  /// use library_stdnums::isbn::ISBN;
-  /// use library_stdnums::traits::Normalize;
+  /// use library_stdnums::ISBN;
+  /// use library_stdnums::Normalize;
   /// assert_eq!(ISBN::new("ISBN: 978-0-306-40615-7").normalize().unwrap(), "9780306406157");
   /// assert_eq!(ISBN::new("0-306-40615-2").normalize().unwrap(), "9780306406157");
   /// ```
@@ -148,8 +148,8 @@ impl Normalize for ISBN {
   /// Returns None if the ISBN is invalid
   ///
   /// ```
-  /// use library_stdnums::isbn::ISBN;
-  /// use library_stdnums::traits::Normalize;
+  /// use library_stdnums::ISBN;
+  /// use library_stdnums::Normalize;
   /// assert_eq!(ISBN::new("013938143").normalize(), None);
   /// ```
   fn normalize(&self) -> Option<String> {

--- a/src/issn.rs
+++ b/src/issn.rs
@@ -11,7 +11,7 @@ impl ISSN {
         }
     }
     /// ```
-    /// use library_stdnums::issn::ISSN;
+    /// use library_stdnums::ISSN;
     /// assert_eq!(ISSN::new("0378-5955").checkdigit(), '5');
     /// ```
     pub fn checkdigit(&self) -> char {
@@ -28,8 +28,8 @@ impl ISSN {
 
 impl Valid for ISSN {
     ///```
-    /// use library_stdnums::issn::ISSN;
-    /// use library_stdnums::traits::Valid;
+    /// use library_stdnums::ISSN;
+    /// use library_stdnums::Valid;
     /// 
     /// assert_eq!(ISSN::new("0378-5955").valid(), true);
     /// assert_eq!(ISSN::new("0378-5951").valid(), false);
@@ -46,8 +46,8 @@ impl Valid for ISSN {
 
 impl Normalize for ISSN {
     ///```
-    /// use library_stdnums::issn::ISSN;
-    /// use library_stdnums::traits::Normalize;
+    /// use library_stdnums::ISSN;
+    /// use library_stdnums::Normalize;
     /// 
     /// assert_eq!(ISSN::new("0378-5955").normalize().unwrap(), "03785955".to_string());
     /// assert!(ISSN::new("abcdefg").normalize().is_none());

--- a/src/lccn.rs
+++ b/src/lccn.rs
@@ -16,8 +16,8 @@ impl LCCN {
 impl Valid for LCCN {
     ///
     /// ```
-    /// use library_stdnums::lccn::LCCN;
-    /// use library_stdnums::traits::Valid;
+    /// use library_stdnums::LCCN;
+    /// use library_stdnums::Valid;
     /// assert!(LCCN::new("n78-890351").valid());
     /// assert!(LCCN::new("  2001045944").valid());
     /// ```
@@ -25,8 +25,8 @@ impl Valid for LCCN {
     /// Returns false if the LCCN content is not valid
     ///
     /// ```
-    /// use library_stdnums::lccn::LCCN;
-    /// use library_stdnums::traits::Valid;
+    /// use library_stdnums::LCCN;
+    /// use library_stdnums::Valid;
     /// assert!(!LCCN::new("Bad LCCN").valid());
     /// assert_eq!(LCCN::new("Bad LCCN").valid(), false);
     /// ```
@@ -67,8 +67,8 @@ impl Normalize for LCCN {
     /// If the LCCN content is valid, it will return it in a `Some`
     ///
     /// ```
-    /// use library_stdnums::lccn::LCCN;
-    /// use library_stdnums::traits::Normalize;
+    /// use library_stdnums::LCCN;
+    /// use library_stdnums::Normalize;
     /// assert_eq!(LCCN::new("n78-890351").normalize(), Some("n78890351".to_string()));
     /// assert_eq!(LCCN::new("n78-890351").normalize().unwrap(), "n78890351");
     /// ```
@@ -76,8 +76,8 @@ impl Normalize for LCCN {
     /// Returns None if the LCCN content is not valid
     ///
     /// ```
-    /// use library_stdnums::lccn::LCCN;
-    /// use library_stdnums::traits::Normalize;
+    /// use library_stdnums::LCCN;
+    /// use library_stdnums::Normalize;
     /// assert!(LCCN::new("Bad LCCN").normalize().is_none());
     /// ```
     fn normalize(&self) -> Option<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
-pub mod isbn;
-pub mod issn;
-pub mod lccn;
-pub mod traits;
+mod isbn;
+mod issn;
+mod lccn;
+mod traits;
+
+pub use isbn::ISBN;
+pub use issn::ISSN;
+pub use lccn::LCCN;
+pub use traits::Normalize;
+pub use traits::Valid;


### PR DESCRIPTION
This allows users of the crate to write this:

```
use library_stdnums::ISBN;
```

Rather than this:
```
use library_stdnums::isbn::ISBN;
```

See [documentation for re-exports in the rustdoc book](https://doc.rust-lang.org/beta/rustdoc/write-documentation/re-exports.html)